### PR TITLE
documentation bug and allow monitoring of labels other than INBOX

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is useful if you spend your day in slack talking with your team and at time
 Installation
 
 1. Download this script
-2. run `pip -r requirements.txt` to install the various libraries required
+2. run `pip install -r requirements.txt` to install the various libraries required
 
 ## Configuration
 

--- a/gmail2slack.py
+++ b/gmail2slack.py
@@ -66,6 +66,11 @@ class Gmail2Slack():
         self.gmail_service = build('gmail', 'v1', http=http)
         self.user_id = 'me'
 
+	if 'gmail_label' in self.config:
+	    self.label_name = self.config['gmail_label']
+	else:
+	    self.label_name = 'INBOX'
+
         try:
             self.state = pickle.load(open(self.config['gmail2slack_pickle'], "rb"))
         except IOError:
@@ -80,9 +85,19 @@ class Gmail2Slack():
         self.state['timestamp'] = arrow.utcnow().timestamp
         pickle.dump(self.state, open(self.config['gmail2slack_pickle'], "wb"))
 
+    def getLabelIdByName(self,name):
+	response=self.gmail_service.users().labels().list(userId=self.user_id).execute()
+	if "labels" in response:
+	    for label in response["labels"]:
+		if label["name"] == name:
+		    return label["id"]
+	return None
+
     def gmail2slack(self):
         try:
-            response = self.gmail_service.users().messages().list(userId=self.user_id, labelIds="INBOX").execute()
+	    label_id = self.getLabelIdByName(self.label_name)
+	    if not label_id: raise Exception("target label name not found")
+            response = self.gmail_service.users().messages().list(userId=self.user_id, labelIds=label_id).execute()
         except AccessTokenRefreshError:
             return
 


### PR DESCRIPTION
Hey, so let me know if this should have been two pull requests.

First commit just fixes a missing word in the docs.

Second commit adds configurable labels.  I'm hoping that should work with how you are monitoring for new messages, but I'm personally using an as-yet-uncommitted version that adds support for using the GMail History API to efficiently poll for new messages.

No worries if you're not actively working/thinking about this anymore -- I'm kind of a GitHub newbie.
